### PR TITLE
string without a thousand separator

### DIFF
--- a/app/bot/utils/__init__.py
+++ b/app/bot/utils/__init__.py
@@ -37,4 +37,4 @@ async def kick_member(bot: Bot, member: MemberDB) -> None:
 
 def amount_string(amount: int, decimals: Optional[int] = None) -> str:
     amount = to_amount(amount, decimals=decimals)  # type: ignore
-    return "{:,.9}".format(Decimal(str(amount))).rstrip('0').rstrip('.')
+    return "{:.9}".format(Decimal(str(amount)))


### PR DESCRIPTION
In the string obtained using the function `"{:,.9}".format(Decimal(str(amount))).rstrip('0').rstrip('.')` integers are incorrectly displayed in after the bot,
The function is used to format the amount as a string separated by thousands and rounded to nine decimal places. When using it, when adding a token with 0 decimal places, the bot displays 1 number (the first digit of the digit). Also, when adding tokens with a decimal separator, a number up to 3 thousand digits is displayed, for example, when specifying 100 tokens with 9 decimal places, the number 1 is displayed, when adding 100,000 tokens with 9 decimal places, the number 100 is displayed, for correct display it is required to specify decimal places, even for whole-numbered tokens. This change changes the formatting.

![image](https://github.com/user-attachments/assets/c5181438-2176-4df7-b9a2-5fc7bcf4d04c)
![image](https://github.com/user-attachments/assets/dd0fce29-86dd-42f7-9788-4fc7b05923de)
100 - 1 (jetton 9 dec)
![image](https://github.com/user-attachments/assets/e84f296e-2764-4cc7-975b-7e68bc6e8024)
![image](https://github.com/user-attachments/assets/638f62b4-d9b7-47ab-a4b0-5f38117eb214)
100.123456789 - 100.12 (jetton 9 dec)
![image](https://github.com/user-attachments/assets/c27ded84-e1ab-4bfd-acb6-4e8c4ccca510)
![image](https://github.com/user-attachments/assets/a86d9c5e-4291-4ae7-8a16-363fe160e730)
150 - 15 (jetton 9 dec)